### PR TITLE
replace as.tibble with as_tibble

### DIFF
--- a/R/Concept.R
+++ b/R/Concept.R
@@ -55,7 +55,7 @@ getConcepts <- function(conceptIds, baseUrl, vocabSourceKey = NULL, snakeCaseToC
     idx <- sapply(x, is.null)
     idx <- names(idx)[idx]
     x[idx] <- NA
-    tibble::as.tibble(x)
+    tibble::as_tibble(x)
   })
   result <- dplyr::bind_rows(lists)
   if (snakeCaseToCamelCase) {


### PR DESCRIPTION
> Warning message:
> `as.tibble()` is deprecated as of tibble 2.0.0.
> Please use `as_tibble()` instead.
> The signature and semantics have changed, see `?as_tibble`.