### PR TITLE
Post concept set

### DIFF
--- a/R/Estimation.R
+++ b/R/Estimation.R
@@ -51,7 +51,7 @@ getEstimationDefinition <- function(baseUrl, estimationId){
     stop(data$payload$message)
   }
   
-  data$specification <- RJSONIO::fromJSON(data$specification)
+  data$specification <- RJSONIO::fromJSON(data$specification, nullValue = NA)
   data$createdDate <- .millisecondsToDate(data$createdDate)
   data$modifiedDate <- .millisecondsToDate(data$modifiedDate)
   

--- a/R/WebApi.R
+++ b/R/WebApi.R
@@ -313,7 +313,7 @@ postDefinition <- function(baseUrl,
   checkmate::assertCharacter(category, add = errorMessage)
   checkmate::assertNames(x = category, subset.of =validCategories )
   checkmate::assertList(x = object, 
-                        types = c('character', 'list'), 
+                        types = c('character', 'list', 'integer', 'numeric'), 
                         any.missing = FALSE,
                         null.ok = FALSE, 
                         add = errorMessage
@@ -322,7 +322,7 @@ postDefinition <- function(baseUrl,
   
   # change category names to comply with difference in webApi
   if (category == 'incidenceRate') {
-    categoryWebApi <- 'iranalysis'
+    categoryWebApi <- 'ir/design'
   } else if (category == 'conceptSet') {
     categoryWebApi <- 'conceptset'
   } else if (category == 'cohort') {

--- a/R/WebApi.R
+++ b/R/WebApi.R
@@ -313,8 +313,8 @@ postDefinition <- function(baseUrl,
   checkmate::assertCharacter(category, add = errorMessage)
   checkmate::assertNames(x = category, subset.of =validCategories )
   checkmate::assertList(x = object, 
-                        types = c('character', 'list', 'integer', 'numeric'), 
-                        any.missing = FALSE,
+                        types = c('character', 'list', 'integer', 'numeric', 'logical'), 
+                        any.missing = TRUE,
                         null.ok = FALSE, 
                         add = errorMessage
   )
@@ -327,6 +327,8 @@ postDefinition <- function(baseUrl,
     categoryWebApi <- 'conceptset'
   } else if (category == 'cohort') {
     categoryWebApi <- 'cohortdefinition'
+  } else if (category == 'estimation') {
+    categoryWebApi <- 'estimation/import'
   } else {categoryWebApi <- category}
   
   # convert R-object to JSON expression.
@@ -386,8 +388,13 @@ postDefinition <- function(baseUrl,
 #  } else if (category == 'incidenceRate') {
     ############### Incidence Rate #########################
     # check if name exists
-    .checkNameExists(urlCheckName)
-  } else {
+  #  .checkNameExists(urlCheckName)
+  # } else if (category == 'estimation') {
+  #   ############### estimation #########################
+  #   # check if name exists
+  #   .checkNameExists(name, baseUrl, category)
+  #   .postJson(name, jsonExpression)
+    } else {
     stop(paste0('category = ', category, " is not supported in this version. Post attempt failed."))
   }
 }

--- a/man/getDefinitionsMetadata.Rd
+++ b/man/getDefinitionsMetadata.Rd
@@ -25,7 +25,9 @@ Retrieve the meta data of all WebApi definitions
 Obtains the meta data of WebApi specifications such as id, name, created/modified 
 details, hash object, etc. The following function categories are supported. 
 Concept-set, Cohort-definition, Cohort-characterization, Pathway-analysis, Incidence rate (ir), 
-estimation and prediction. This function is useful to retrieve the current specifications.
+estimation and prediction. They should be referenced using string 
+'conceptSet','cohort', 'characterization', 'pathway', 'incidenceRate', 'estimation','prediction' 
+ only. This function is useful to retrieve the current specifications.
 }
 \examples{
 \dontrun{

--- a/man/postDefinition.Rd
+++ b/man/postDefinition.Rd
@@ -4,7 +4,7 @@
 \alias{postDefinition}
 \title{Post a definition into WebApi}
 \usage{
-postDefinition(baseUrl, name, type = "cohort", object)
+postDefinition(baseUrl, name, category = "cohort", object)
 }
 \arguments{
 \item{baseUrl}{The base URL for the WebApi instance, for example:
@@ -15,8 +15,12 @@ If trailing '/' is used, you may receive an error.}
 the name of the definition. WebApi checks for validity,
 such as uniqueness, unaccepted character etc. An error might be thrown.}
 
-\item{type}{The type of expression in WebApi. Currently only 'cohort' is supported 
-to refer cohort definition specification expression.}
+\item{category}{The category of expression in WebApi. Currently only 'cohort' is supported,but
+we will support posting the definitions of Concept-set, Cohort-definition, 
+Cohort-characterization, Pathway-analysis, Incidence rate (ir), 
+estimation and prediction. They should be referenced using string 
+'conceptSet','cohort', 'characterization', 'pathway', 'incidenceRate', 
+'estimation','prediction' only.}
 
 \item{object}{An R list object containing the expression for the specification. 
 This will be converted to JSON by function and posted into the WebApi.
@@ -38,8 +42,9 @@ Post a definition into WebAPI
 \dontrun{
 validJsonExpression <- getCohortDefinition(baseUrl = baseUrl, 
                                            cohortId = 15873)$expression
-postSpecification(name = 'new name for expression in target',
+postDefinition(name = 'new name for expression in target',
                   baseUrl = "http://server.org:80/WebAPI",
-                  jsonExpression = validJsonExpression)
+                  object = validJsonExpression,
+                  category = 'cohort')
 }
 }

--- a/man/postDefinition.Rd
+++ b/man/postDefinition.Rd
@@ -4,7 +4,7 @@
 \alias{postDefinition}
 \title{Post a definition into WebApi}
 \usage{
-postDefinition(baseUrl, name, category = "cohort", object)
+postDefinition(baseUrl, name, category, object)
 }
 \arguments{
 \item{baseUrl}{The base URL for the WebApi instance, for example:


### PR DESCRIPTION
Addresses https://github.com/OHDSI/ROhdsiWebApi/issues/106

With this PR we are able to post definitions of Cohorts and ConceptSets. 

- this code will check if a name assigned to the expression in the target WebApi - exists in the target WebApi (if yes, throws an error)
- posts the expression. If failed, it will return error message. If success, it will return details of the posted expression.

This framework is working for cohort and conceptset, but not incidence rate, pathways, cohort characterization, estimation or prediction. Tagging @chrisknoll @anthonysena  - as i may need guidance from you two

@schuemie could you please review this code