### PR TITLE
Add option to use a bearerToken in getCdmSources.  #35

### DIFF
--- a/R/WebApi.R
+++ b/R/WebApi.R
@@ -101,15 +101,26 @@ getWebApiVersion <- function(baseUrl) {
 #' Obtains the data sources configured in the WebAPI instance.
 #'
 #' @template BaseUrl
-#'
+#' @param bearerToken A bearer token used to authenticate to WebAPI. Can be NULL (default)
+#'                    or a character string containing a bearer token that can be used to 
+#'                    authenticate to WebAPI.
+#'                    
 #' @return
 #' A data frame.
-#'
+#' 
 #' @export
-getCdmSources <- function(baseUrl) {
+getCdmSources <- function(baseUrl, bearerToken = NULL) {
   .checkBaseUrl(baseUrl)
   url <- sprintf("%s/source/sources", baseUrl)
-  request <- httr::GET(url)
+  
+  if (is.null(bearer)) {
+    request <- httr::GET(url)
+  } else if (is.character(bearerToken) & length(bearerToken) == 1) {
+    request <- httr::GET(url, httr::add_headers(Authorization = bearerToken))
+  } else {
+    stop("The bearerToken argument should be a character vector of length 1 or NULL.")
+  }
+  
   httr::stop_for_status(request)
   sources <- httr::content(request)
   

--- a/tests/testthat/test-webapi.R
+++ b/tests/testthat/test-webapi.R
@@ -1,7 +1,16 @@
 library(testthat)
 
 baseUrl <- Sys.getenv("ohdsiBaseUrl")
+testAuthMethod <- Sys.getenv("testAuthMethod")
+keyringUsername <- Sys.getenv("keyringUsername")
+bearerToken <- NULL
 
+test_that("Test createBearerToken", {
+  authMethods <- c("db")
+  skip_if(!(testAuthMethod %in% authMethods) | baseUrl == "" | keyringUsername == "")
+  bearerToken <<- createBearerToken(baseUrl, testAuthMethod, keyringUsername)
+  expect_match(bearerToken, "^Bearer .+$")
+})
 
 test_that("Test .checkBaseUrl", {
   skip_if(baseUrl == "")
@@ -12,7 +21,7 @@ test_that("Test .checkBaseUrl", {
 
 test_that("Test getCdmSources", {
   skip_if(baseUrl == "")
-  cdmSources <- getCdmSources(baseUrl = baseUrl)
+  cdmSources <- getCdmSources(baseUrl = baseUrl, bearerToken = bearerToken)
   expect_s3_class(cdmSources, "data.frame")
   expect_gt(nrow(cdmSources), 0)
 })


### PR DESCRIPTION
Adding a bearerToken argument to the getCdmSources function so that users can pass in a token and use this function. Github issue #35