### PR TITLE
Add class attribute to WebAPI objects like cohorts and concept sets

### DIFF
--- a/R/CohortDefinition.R
+++ b/R/CohortDefinition.R
@@ -282,7 +282,8 @@ getCohortSql <- function(cohortDefinition, baseUrl, generateStats = TRUE) {
   }
 }
 
-# A print method for cohort objects
+#' A print method for cohort objects
+#' @export
 print.cohort <- function(x) {
   print(str(x, max.level = 1))
 }

--- a/R/CohortDefinition.R
+++ b/R/CohortDefinition.R
@@ -281,3 +281,8 @@ getCohortSql <- function(cohortDefinition, baseUrl, generateStats = TRUE) {
     stop()
   }
 }
+
+# A print method for cohort objects
+print.cohort <- function(x) {
+  print(str(x, max.level = 1))
+}

--- a/R/GetDefinition.R
+++ b/R/GetDefinition.R
@@ -89,5 +89,5 @@ getDefinition <- function(id, category, baseUrl) {
       response$expression <- RJSONIO::fromJSON(response$expression, nullValue = NA)
     }
   }
-  return(response)
+  return(structure(response, class = category))
 }


### PR DESCRIPTION
I'd like to get feedback on the idea of adding a class attribute to WebAPI/Atlas objects like cohorts, concept sets, etc. This would allow us to do things like add a print method so objects will look nice when printed to the console. A simple example is included in this draft pull request for cohorts. Additionally it could allow for a nice interface using generic functions such as `generate()`, `execute()`, `getSql()`, `post()` that would accept different types of WebAPI objects (characterization, pathway, incidence rate) and perform the appropriate action based on the the type of object passed to the generic function.

```
baseUrl <- "http://webapi"

# execute a characterization 
execute(someCharacterization, baseUrl)

# execute a pathway analysis
execute(someIncidencePathwayAnalysis, baseUrl)

# execute an incidence rate analysis
execute(someIncidenceRateAnalysis, baseUrl)

# post a characterization 
post(someCharacterization, baseUrl)

# post a pathway analysis
post(someIncidencePathwayAnalysis, baseUrl)

# post an incidence rate analysis
post(someIncidenceRateAnalysis, baseUrl)
```