### PR TITLE
reverted to old use of jsonlite which formats JSON objects from data frames very differently.

### DIFF
--- a/R/PostDefinition.R
+++ b/R/PostDefinition.R
@@ -101,7 +101,7 @@ postDefinition <- function(baseUrl, name, category, definition) {
                     .data$isExcluded,
                     .data$includeMapped,
                     .data$includeDescendants)
-    expression <- RJSONIO::toJSON(x = items, digits = 23, pretty = TRUE)
+    expression <- jsonlite::toJSON(x = items)
     responsePut <- .putJson(url = paste0(baseUrl,
                                          "/",
                                          argument$categoryUrl,


### PR DESCRIPTION
This was creating an issue with `postCohortDefinition`

E.g.
```
cohort_definition <-
  getCohortDefinition(cohortId = 15997, baseUrl = baseUrl)
postCohort <-
  postCohortDefinition(
    name = paste0("this is part of a test and may be deleted ", tempfile() %>% basename()),
    cohortDefinition = cohort_definition,
    baseUrl = baseUrl
  )
```

Would throw a 400 error.

This PR reverts to use of jsonlite from RJSONIO which was changed in another commit.

The issue is with how R data frames are encoded. For example:

```
> data <- data.frame(a=1,b=2)
> RJSONIO::toJSON(data)
[1] "{\n \"a\": [        1 ],\n\"b\": [        2 ] \n}"

> jsonlite::toJSON(data)
[{"a":1,"b":2}] 
```

I've reverted to using Json lite because a) this is the format WebApi expects b) its still used elsewhere in the codebase and c) their transformation of data frames to a json string is probably more efficient and better tested than anything we should bother trying to write quickly.