### PR TITLE
Remove Plumber etc from description dependencies

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yml
+++ b/.github/workflows/R_CMD_check_Hades.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Query dependencies
         run: |
           install.packages('remotes')
+          install.packages(c('plumber', 'httpuv', 'callr'))
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,10 +34,7 @@ Suggests:
     testthat,
     knitr,
     rmarkdown,
-    httpuv,
-    jsonlite,
-    plumber,
-    callr
+    jsonlite
 URL: https://github.com/OHDSI/ROhdsiWebApi
 BugReports: https://github.com/OHDSI/ROhdsiWebApi/issues
 NeedsCompilation: no


### PR DESCRIPTION
Added plumber, httpuv, callr to github actions instead of DESCRIPTION