### PR TITLE
Revert PR #181 and remove live webapi from build tests

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yml
+++ b/.github/workflows/R_CMD_check_Hades.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Query dependencies
         run: |
           install.packages('remotes')
-          install.packages(c('plumber', 'httpuv', 'callr'))
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}

--- a/.github/workflows/R_CMD_check_Hades.yml
+++ b/.github/workflows/R_CMD_check_Hades.yml
@@ -43,7 +43,6 @@ jobs:
       CDM5_SQL_SERVER_PASSWORD: ${{ secrets.CDM5_SQL_SERVER_PASSWORD }}
       CDM5_SQL_SERVER_SERVER: ${{ secrets.CDM5_SQL_SERVER_SERVER }}
       CDM5_SQL_SERVER_USER: ${{ secrets.CDM5_SQL_SERVER_USER }}
-      ohdsiBaseUrl: 'http://api.ohdsi.org:8080/WebAPI'
 
     steps:
       - uses: actions/checkout@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,10 @@ Suggests:
     testthat,
     knitr,
     rmarkdown,
-    jsonlite
+    httpuv,
+    jsonlite,
+    plumber,
+    callr
 URL: https://github.com/OHDSI/ROhdsiWebApi
 BugReports: https://github.com/OHDSI/ROhdsiWebApi/issues
 NeedsCompilation: no


### PR DESCRIPTION
We need to have test dependencies in the DESCRIPTION file as this stops warnings in the install check. The original PR was merged before build completed so this was missed.