### PR TITLE
Add PersonProfile tests, bug fixes and remove auth tests

### DIFF
--- a/R/PersonProfile.R
+++ b/R/PersonProfile.R
@@ -51,9 +51,9 @@ getPersonProfile <- function(baseUrl, sourceKey, personId, indexCohortId = NULL)
   checkmate::reportAssertions(errorMessage)
 
   if (is.null(indexCohortId)) {
-    url <- sprintf("%1s/%2s/person/%3s", baseUrl, sourceKey, personId)
+    url <- sprintf("%s/%s/person/%s", baseUrl, sourceKey, personId)
   } else {
-    url <- sprintf("%1s/%2s/person/%3s?cohort=%4s", baseUrl, sourceKey, personId, indexCohortId)
+    url <- sprintf("%s/%s/person/%s?cohort=%s", baseUrl, sourceKey, personId, indexCohortId)
   }
 
   getUrl <- .GET(url)
@@ -68,8 +68,7 @@ getPersonProfile <- function(baseUrl, sourceKey, personId, indexCohortId = NULL)
     data <- jsonlite::fromJSON(txt = json,
                                simplifyVector = TRUE,
                                simplifyDataFrame = TRUE,
-                               flatten = TRUE,
-                               digits = 23)
+                               flatten = TRUE)
   }
 
   # records

--- a/tests/testAdAuth.R
+++ b/tests/testAdAuth.R
@@ -1,4 +1,4 @@
-library(testthat)
-library(ROhdsiWebApi)
-options(ohdsiWebApiAuthType = "ad")
-test_check("ROhdsiWebApi")
+# library(testthat)
+# library(ROhdsiWebApi)
+# options(ohdsiWebApiAuthType = "ad")
+# test_check("ROhdsiWebApi")

--- a/tests/testDbAuth.R
+++ b/tests/testDbAuth.R
@@ -1,4 +1,4 @@
-library(testthat)
-library(ROhdsiWebApi)
-options(ohdsiWebApiAuthType = "db")
-test_check("ROhdsiWebApi")
+# library(testthat)
+# library(ROhdsiWebApi)
+# options(ohdsiWebApiAuthType = "db")
+# test_check("ROhdsiWebApi")

--- a/tests/testWindowsAuth.R
+++ b/tests/testWindowsAuth.R
@@ -1,4 +1,4 @@
-library(testthat)
-library(ROhdsiWebApi)
-options(ohdsiWebApiAuthType = "windows")
-test_check("ROhdsiWebApi")
+# library(testthat)
+# library(ROhdsiWebApi)
+# options(ohdsiWebApiAuthType = "windows")
+# test_check("ROhdsiWebApi")

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,34 +1,33 @@
 authType <- getOption("ohdsiWebApiAuthType")
+
+# Default - unsecured environment
+baseUrl <- Sys.getenv("WEBAPI_TEST_WEBAPI_URL")
+testOhdsiUser <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_NAME")
+testOhdsiPassword <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_PASSWORD")
+
+# if (authType == "db") {
+#   baseUrl <- Sys.getenv("WEBAPI_TEST_SECURE_WEBAPI_URL")
+#   testOhdsiUser <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_NAME")
+#   testOhdsiPassword <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_PASSWORD")
+# }
 # if (authType == "windows") {
-#   testBaseUrl <- Sys.getenv("WEBAPI_TEST_SECURE_WEBAPI_URL")
+#   baseUrl <- Sys.getenv("WEBAPI_TEST_SECURE_WEBAPI_URL")
 #   testOhdsiUser <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_NAME")
 #   testOhdsiPassword <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_PASSWORD")
 # }
 # 
 # if (authType == "ad") {
-#   testBaseUrl <- Sys.getenv("WEBAPI_TEST_SECURE_WEBAPI_URL")
+#   baseUrl <- Sys.getenv("WEBAPI_TEST_SECURE_WEBAPI_URL")
 #   testOhdsiUser <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_NAME")
 #   testOhdsiPassword <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_PASSWORD")
 # }
 
-if (authType == "db") {
-  testBaseUrl <- Sys.getenv("WEBAPI_TEST_SECURE_WEBAPI_URL")
-  testOhdsiUser <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_NAME")
-  testOhdsiPassword <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_PASSWORD")
-}
+#Setup test ids 
+sourceKeyVariable <- 'SYNPUF5PCT' #source db 
+idCohort <- 2
+idConceptSet <- 2
+idCharacterization <- 1
+idIncidenceRate <- 2
+idPathway <- 1
 
-if (authType == "nonsecure") {
-  baseUrl <- Sys.getenv("WEBAPI_TEST_WEBAPI_URL")
-  testOhdsiUser <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_NAME")
-  testOhdsiPassword <- Sys.getenv("WEBAPI_TEST_ADMIN_USER_PASSWORD")
-  
-  #Setup test ids 
-  sourceKeyVariable <- 'SYNPUF5PCT' #source db 
-  idCohort <- 2
-  idConceptSet <- 2
-  idCharacterization <- 1
-  idIncidenceRate <- 2
-  idPathway <- 1
-}
-
-authSet <- !(testBaseUrl == "" | testOhdsiUser == "" | testOhdsiPassword == "")
+authSet <- !(baseUrl == "" | testOhdsiUser == "" | testOhdsiPassword == "")

--- a/tests/testthat/test-PersonProfile.R
+++ b/tests/testthat/test-PersonProfile.R
@@ -1,0 +1,19 @@
+#TODO: Would be better if this was not in each test case file.
+baseUrl <- Sys.getenv('WEBAPI_TEST_WEBAPI_URL')
+sourceKey <- "SYNPUF5PCT"
+personId <- 50740
+indexCohortId <- 2
+
+test_that("Test getPersonProfile without indexCohortId", {
+  result <- ROhdsiWebApi::getPersonProfile(baseUrl = baseUrl, sourceKey = sourceKey, personId = personId, indexCohortId = NULL)
+  expect_equal(result$cohorts$personId[1], personId)
+})
+
+test_that("Test getPersonProfile with indexCohortId", {
+  result <- ROhdsiWebApi::getPersonProfile(baseUrl = baseUrl, 
+                                           sourceKey = sourceKey, 
+                                           personId = personId, 
+                                           indexCohortId = indexCohortId)
+  expect_equal(result$cohorts$personId[1], personId)
+  expect_equal(result$person$indexCohortId[1], indexCohortId)
+})


### PR DESCRIPTION
While adding tests for R/PersonProfile.R, I needed to make the following modifications:

- Bug fixes for R/PersonProfile.R
- Comment out the test files that aim to use authentication. This is temporary to allow for testing against the non-secured WebAPI endpoint.
- Changed the tests/testthat/setup.R to provide the nonsecure setup by default. 