### PR TITLE
Use bearer token with {baseUrl}/info endpoint if a token exists.

### DIFF
--- a/R/WebApi.R
+++ b/R/WebApi.R
@@ -61,7 +61,7 @@ getWebApiVersion <- function(baseUrl) {
   
   url <- paste0(baseUrl, "/info")
   
-  response <- httr::GET(url)
+  response <- .GET(url)
   if (response$status %in% c(200)) {
     version <- (httr::content(response))$version
   } else {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,6 +1,7 @@
 ## Setup file for ROhdsiWebApi tests -----------------
 library(httptest)
 
+
 ## set up Environmental variables
 baseUrl <- Sys.getenv("WEBAPI_TEST_WEBAPI_URL") #nonsecure test environment
 sourceKeyVariable <- 'SYNPUF5PCT' #source db 


### PR DESCRIPTION
Fixes issue #251 by adding a bearer token to calls to the "info" endpoint if a bearer token exists. 